### PR TITLE
docs(site): add roadmap page to documentation website

### DIFF
--- a/site/content/en/docs/_index.md
+++ b/site/content/en/docs/_index.md
@@ -68,6 +68,7 @@ flowchart TB
   {{< card link="core-concepts" title="Core Concepts" subtitle="Understand Virtual DOM, State, Components, and Events" >}}
   {{< card link="architecture" title="Architecture" subtitle="Deep dive into Zylix internals" >}}
   {{< card link="platforms" title="Platform Guides" subtitle="Platform-specific setup and best practices" >}}
+  {{< card link="roadmap" title="Roadmap" subtitle="Future plans: Components, Routing, Async, Hot Reload" >}}
 {{< /cards >}}
 
 ## Supported Platforms

--- a/site/content/en/docs/roadmap.md
+++ b/site/content/en/docs/roadmap.md
@@ -1,0 +1,270 @@
+---
+title: Roadmap
+weight: 5
+prev: platforms
+---
+
+This page outlines the development roadmap for Zylix beyond v0.1.0. Each phase introduces new capabilities while maintaining the framework's core principles of performance, simplicity, and native platform integration.
+
+## Current Status
+
+**Version 0.1.0** is complete with:
+
+- ✅ Virtual DOM engine with efficient diffing
+- ✅ Type-safe state management
+- ✅ Component system with 9 basic components
+- ✅ CSS utility system (TailwindCSS-like)
+- ✅ Flexbox layout engine
+- ✅ 6-platform support (Web, iOS, Android, macOS, Linux, Windows)
+- ✅ C ABI and WASM bindings
+
+## Roadmap Overview
+
+```mermaid
+gantt
+    title Zylix Development Roadmap
+    dateFormat  YYYY-MM
+    section Foundation
+    v0.1.0 Complete           :done, v010, 2024-01, 2024-12
+    section Phase 6-10
+    v0.2.0 Components         :v020, 2025-01, 2025-03
+    v0.3.0 Routing            :v030, 2025-04, 2025-05
+    v0.4.0 Async              :v040, 2025-05, 2025-06
+    v0.5.0 Hot Reload         :v050, 2025-07, 2025-08
+    v0.6.0 Sample Apps        :v060, 2025-08, 2025-09
+```
+
+## Phase 6: Component Library (v0.2.0)
+
+Expand from 9 basic components to 30+ comprehensive UI components.
+
+### Planned Components
+
+{{< tabs items="Form,Layout,Navigation,Feedback,Data" >}}
+
+{{< tab >}}
+| Component | Description | Priority |
+|-----------|-------------|----------|
+| `select` | Dropdown/picker | P0 |
+| `checkbox` | Boolean toggle | P0 |
+| `radio` | Single selection | P0 |
+| `textarea` | Multi-line input | P0 |
+| `switch` | Toggle switch | P1 |
+| `slider` | Range input | P1 |
+| `date_picker` | Date selection | P1 |
+| `time_picker` | Time selection | P1 |
+| `form` | Form container | P0 |
+{{< /tab >}}
+
+{{< tab >}}
+| Component | Description | Priority |
+|-----------|-------------|----------|
+| `stack` | V/H stack | P0 |
+| `grid` | CSS Grid layout | P0 |
+| `scroll_view` | Scrollable container | P0 |
+| `spacer` | Flexible space | P0 |
+| `divider` | Visual separator | P1 |
+| `card` | Card container | P1 |
+| `safe_area` | Safe area insets | P1 |
+{{< /tab >}}
+
+{{< tab >}}
+| Component | Description | Priority |
+|-----------|-------------|----------|
+| `nav_bar` | Navigation bar | P0 |
+| `tab_bar` | Tab navigation | P0 |
+| `drawer` | Side drawer | P1 |
+| `breadcrumb` | Breadcrumb nav | P2 |
+| `pagination` | Page navigation | P2 |
+{{< /tab >}}
+
+{{< tab >}}
+| Component | Description | Priority |
+|-----------|-------------|----------|
+| `alert` | Alert dialog | P0 |
+| `toast` | Toast notification | P0 |
+| `modal` | Modal dialog | P0 |
+| `progress` | Progress indicator | P1 |
+| `spinner` | Loading spinner | P1 |
+| `badge` | Notification badge | P1 |
+{{< /tab >}}
+
+{{< tab >}}
+| Component | Description | Priority |
+|-----------|-------------|----------|
+| `table` | Data table | P1 |
+| `avatar` | User avatar | P1 |
+| `icon` | Icon component | P0 |
+| `tag` | Label/tag | P1 |
+| `accordion` | Expandable sections | P1 |
+{{< /tab >}}
+
+{{< /tabs >}}
+
+### Implementation
+
+```zig
+pub const ComponentType = enum(u8) {
+    // Existing (0-9)
+    container = 0, text = 1, button = 2, ...
+
+    // Form (10-19)
+    select = 10, checkbox = 11, radio = 12, ...
+
+    // Layout (20-29)
+    stack = 20, grid = 21, scroll_view = 22, ...
+
+    // Navigation (30-39)
+    nav_bar = 30, tab_bar = 31, drawer = 32, ...
+
+    // Feedback (40-49)
+    alert = 40, toast = 41, modal = 42, ...
+};
+```
+
+## Phase 7: Routing System (v0.3.0)
+
+Cross-platform navigation with deep linking support.
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph Router["Zylix Router (Zig Core)"]
+        Routes["Route Definitions"]
+        Matcher["URL Matcher"]
+        History["Navigation History"]
+        Guards["Route Guards"]
+    end
+
+    subgraph Platforms["Platform Integration"]
+        iOS["iOS<br/>NavigationStack"]
+        Android["Android<br/>Navigation Compose"]
+        Web["Web<br/>History API"]
+        Desktop["Desktop<br/>Stack Navigation"]
+    end
+
+    Router --> |C ABI| Platforms
+```
+
+### Features
+
+- **Path patterns**: `/users/:id/posts`
+- **Query parameters**: `?page=1&sort=date`
+- **Route guards**: Authentication, permissions
+- **Deep linking**: Universal Links, App Links
+- **History management**: Back, forward, replace
+
+### API Preview
+
+```zig
+const routes = [_]Route{
+    .{ .path = "/", .component = home_component },
+    .{ .path = "/users/:id", .component = user_component },
+    .{ .path = "/settings", .component = settings_component, .guards = &[_]Guard{auth_guard} },
+};
+
+// Navigation
+router.push("/users/123");
+router.back();
+
+// Access params
+const user_id = router.getParams().get("id");
+```
+
+## Phase 8: Async Processing (v0.4.0)
+
+Async/await patterns for HTTP, file I/O, and background tasks.
+
+### Features
+
+- **Future/Promise**: Chainable async operations
+- **HTTP Client**: GET, POST, PUT, DELETE with JSON support
+- **Background Tasks**: Scheduled and repeating tasks
+- **Cancellation**: Timeout and manual cancellation
+
+### API Preview
+
+```zig
+// HTTP request
+const response = try HttpClient.get("https://api.example.com/users")
+    .then(fn(resp) { return resp.json(User); })
+    .await();
+
+// Background task
+const handle = TaskRunner.schedule(
+    .{ .work_fn = sync_data },
+    Duration.minutes(5),
+);
+```
+
+### Platform Integration
+
+| Platform | Runtime | HTTP | Background |
+|----------|---------|------|------------|
+| iOS | Swift Concurrency | URLSession | Background Tasks |
+| Android | Coroutines | OkHttp | WorkManager |
+| Web | Promise | Fetch API | Web Workers |
+| Desktop | Thread Pool | libcurl/WinHTTP | Native threads |
+
+## Phase 9: Hot Reload (v0.5.0)
+
+Development-time code reloading with state preservation.
+
+### Features
+
+- **File watching**: < 100ms detection
+- **Incremental builds**: < 1s for small changes
+- **State preservation**: Maintain app state across reloads
+- **Error overlay**: Source-mapped error display
+
+### CLI Commands
+
+```bash
+# Start dev server with hot reload
+zylix dev --platform web --port 3000
+
+# iOS Simulator with hot reload
+zylix dev --platform ios-sim --hot
+
+# All platforms
+zylix dev --all
+```
+
+## Phase 10: Sample Applications (v0.6.0)
+
+Comprehensive examples demonstrating real-world patterns.
+
+### Planned Apps
+
+| App | Level | Demonstrates |
+|-----|-------|--------------|
+| **Todo Pro** | Beginner | State, forms, storage |
+| **E-Commerce** | Intermediate | Routing, HTTP, auth |
+| **Dashboard** | Intermediate | Charts, tables, real-time |
+| **Chat** | Advanced | WebSocket, push notifications |
+| **Notes** | Advanced | Rich text, search, sync |
+
+Each app will include:
+- Full source code for all 6 platforms
+- Step-by-step tutorials
+- Architecture documentation
+- Performance benchmarks
+
+## Contributing
+
+We welcome contributions! See our [Contributing Guide](https://github.com/kotsutsumi/zylix/blob/main/CONTRIBUTING.md) for details.
+
+### Priority Areas
+
+1. Component implementations (v0.2.0)
+2. Platform shell updates
+3. Documentation improvements
+4. Sample applications
+
+## Detailed Roadmap
+
+For complete implementation details, see the full roadmap documents:
+
+- [ROADMAP.md](https://github.com/kotsutsumi/zylix/blob/main/docs/ROADMAP.md) (English)
+- [ROADMAP.ja.md](https://github.com/kotsutsumi/zylix/blob/main/docs/ROADMAP.ja.md) (Japanese)

--- a/site/content/ja/docs/_index.md
+++ b/site/content/ja/docs/_index.md
@@ -104,6 +104,12 @@ python3 -m http.server 8080
   {{< card link="platforms" title="プラットフォームガイド" subtitle="全6プラットフォームの統合ガイド" >}}
 {{< /cards >}}
 
+### ロードマップ
+
+{{< cards >}}
+  {{< card link="roadmap" title="ロードマップ" subtitle="今後の計画：コンポーネント、ルーティング、非同期処理、Hot Reload" >}}
+{{< /cards >}}
+
 ## 対応プラットフォーム
 
 | プラットフォーム | UI フレームワーク | 言語 | バインディング | 最小バージョン |

--- a/site/content/ja/docs/roadmap.md
+++ b/site/content/ja/docs/roadmap.md
@@ -1,0 +1,270 @@
+---
+title: ロードマップ
+weight: 5
+prev: platforms
+---
+
+このページでは、v0.1.0以降のZylix開発ロードマップを説明します。各フェーズでは、パフォーマンス、シンプルさ、ネイティブプラットフォーム統合というフレームワークの核心原則を維持しながら、新しい機能を導入します。
+
+## 現在の状況
+
+**バージョン 0.1.0** は以下を完了しています：
+
+- ✅ 効率的な差分計算を持つVirtual DOMエンジン
+- ✅ 型安全な状態管理
+- ✅ 9種類の基本コンポーネントを持つコンポーネントシステム
+- ✅ CSSユーティリティシステム（TailwindCSS風）
+- ✅ Flexboxレイアウトエンジン
+- ✅ 6プラットフォーム対応（Web、iOS、Android、macOS、Linux、Windows）
+- ✅ C ABIとWASMバインディング
+
+## ロードマップ概要
+
+```mermaid
+gantt
+    title Zylix 開発ロードマップ
+    dateFormat  YYYY-MM
+    section 基盤
+    v0.1.0 完了               :done, v010, 2024-01, 2024-12
+    section Phase 6-10
+    v0.2.0 コンポーネント     :v020, 2025-01, 2025-03
+    v0.3.0 ルーティング       :v030, 2025-04, 2025-05
+    v0.4.0 非同期処理         :v040, 2025-05, 2025-06
+    v0.5.0 Hot Reload         :v050, 2025-07, 2025-08
+    v0.6.0 サンプルアプリ     :v060, 2025-08, 2025-09
+```
+
+## Phase 6: コンポーネントライブラリ (v0.2.0)
+
+9種類の基本コンポーネントから30種類以上の包括的なUIコンポーネントに拡張します。
+
+### 追加予定コンポーネント
+
+{{< tabs items="フォーム,レイアウト,ナビゲーション,フィードバック,データ表示" >}}
+
+{{< tab >}}
+| コンポーネント | 説明 | 優先度 |
+|--------------|------|-------|
+| `select` | ドロップダウン/ピッカー | P0 |
+| `checkbox` | ブール値トグル | P0 |
+| `radio` | 単一選択 | P0 |
+| `textarea` | 複数行入力 | P0 |
+| `switch` | トグルスイッチ | P1 |
+| `slider` | レンジ入力 | P1 |
+| `date_picker` | 日付選択 | P1 |
+| `time_picker` | 時刻選択 | P1 |
+| `form` | フォームコンテナ | P0 |
+{{< /tab >}}
+
+{{< tab >}}
+| コンポーネント | 説明 | 優先度 |
+|--------------|------|-------|
+| `stack` | 縦/横スタック | P0 |
+| `grid` | CSSグリッドレイアウト | P0 |
+| `scroll_view` | スクロール可能コンテナ | P0 |
+| `spacer` | 柔軟なスペース | P0 |
+| `divider` | 視覚的区切り | P1 |
+| `card` | カードコンテナ | P1 |
+| `safe_area` | セーフエリアインセット | P1 |
+{{< /tab >}}
+
+{{< tab >}}
+| コンポーネント | 説明 | 優先度 |
+|--------------|------|-------|
+| `nav_bar` | ナビゲーションバー | P0 |
+| `tab_bar` | タブナビゲーション | P0 |
+| `drawer` | サイドドロワー | P1 |
+| `breadcrumb` | パンくずナビ | P2 |
+| `pagination` | ページナビゲーション | P2 |
+{{< /tab >}}
+
+{{< tab >}}
+| コンポーネント | 説明 | 優先度 |
+|--------------|------|-------|
+| `alert` | アラートダイアログ | P0 |
+| `toast` | トースト通知 | P0 |
+| `modal` | モーダルダイアログ | P0 |
+| `progress` | プログレスインジケーター | P1 |
+| `spinner` | ローディングスピナー | P1 |
+| `badge` | 通知バッジ | P1 |
+{{< /tab >}}
+
+{{< tab >}}
+| コンポーネント | 説明 | 優先度 |
+|--------------|------|-------|
+| `table` | データテーブル | P1 |
+| `avatar` | ユーザーアバター | P1 |
+| `icon` | アイコンコンポーネント | P0 |
+| `tag` | ラベル/タグ | P1 |
+| `accordion` | 展開可能セクション | P1 |
+{{< /tab >}}
+
+{{< /tabs >}}
+
+### 実装
+
+```zig
+pub const ComponentType = enum(u8) {
+    // 既存 (0-9)
+    container = 0, text = 1, button = 2, ...
+
+    // フォーム (10-19)
+    select = 10, checkbox = 11, radio = 12, ...
+
+    // レイアウト (20-29)
+    stack = 20, grid = 21, scroll_view = 22, ...
+
+    // ナビゲーション (30-39)
+    nav_bar = 30, tab_bar = 31, drawer = 32, ...
+
+    // フィードバック (40-49)
+    alert = 40, toast = 41, modal = 42, ...
+};
+```
+
+## Phase 7: ルーティングシステム (v0.3.0)
+
+ディープリンクサポート付きのクロスプラットフォームナビゲーション。
+
+### アーキテクチャ
+
+```mermaid
+flowchart TB
+    subgraph Router["Zylix Router (Zig Core)"]
+        Routes["ルート定義"]
+        Matcher["URLマッチャー"]
+        History["ナビゲーション履歴"]
+        Guards["ルートガード"]
+    end
+
+    subgraph Platforms["プラットフォーム統合"]
+        iOS["iOS<br/>NavigationStack"]
+        Android["Android<br/>Navigation Compose"]
+        Web["Web<br/>History API"]
+        Desktop["デスクトップ<br/>スタックナビゲーション"]
+    end
+
+    Router --> |C ABI| Platforms
+```
+
+### 機能
+
+- **パスパターン**: `/users/:id/posts`
+- **クエリパラメータ**: `?page=1&sort=date`
+- **ルートガード**: 認証、権限
+- **ディープリンク**: Universal Links、App Links
+- **履歴管理**: 戻る、進む、置換
+
+### APIプレビュー
+
+```zig
+const routes = [_]Route{
+    .{ .path = "/", .component = home_component },
+    .{ .path = "/users/:id", .component = user_component },
+    .{ .path = "/settings", .component = settings_component, .guards = &[_]Guard{auth_guard} },
+};
+
+// ナビゲーション
+router.push("/users/123");
+router.back();
+
+// パラメータアクセス
+const user_id = router.getParams().get("id");
+```
+
+## Phase 8: 非同期処理 (v0.4.0)
+
+HTTP、ファイルI/O、バックグラウンドタスク用のasync/awaitパターン。
+
+### 機能
+
+- **Future/Promise**: チェーン可能な非同期操作
+- **HTTPクライアント**: JSONサポート付きGET、POST、PUT、DELETE
+- **バックグラウンドタスク**: スケジュールおよび繰り返しタスク
+- **キャンセル**: タイムアウトと手動キャンセル
+
+### APIプレビュー
+
+```zig
+// HTTPリクエスト
+const response = try HttpClient.get("https://api.example.com/users")
+    .then(fn(resp) { return resp.json(User); })
+    .await();
+
+// バックグラウンドタスク
+const handle = TaskRunner.schedule(
+    .{ .work_fn = sync_data },
+    Duration.minutes(5),
+);
+```
+
+### プラットフォーム統合
+
+| プラットフォーム | ランタイム | HTTP | バックグラウンド |
+|--------------|---------|------|------------|
+| iOS | Swift Concurrency | URLSession | Background Tasks |
+| Android | Coroutines | OkHttp | WorkManager |
+| Web | Promise | Fetch API | Web Workers |
+| デスクトップ | Thread Pool | libcurl/WinHTTP | ネイティブスレッド |
+
+## Phase 9: Hot Reload (v0.5.0)
+
+状態保持付きの開発時コードリロード。
+
+### 機能
+
+- **ファイル監視**: < 100ms検出
+- **インクリメンタルビルド**: 小さな変更で < 1秒
+- **状態保持**: リロード間でアプリ状態を維持
+- **エラーオーバーレイ**: ソースマップ付きエラー表示
+
+### CLIコマンド
+
+```bash
+# ホットリロード付き開発サーバー起動
+zylix dev --platform web --port 3000
+
+# ホットリロード付きiOSシミュレーター
+zylix dev --platform ios-sim --hot
+
+# 全プラットフォーム
+zylix dev --all
+```
+
+## Phase 10: サンプルアプリケーション (v0.6.0)
+
+実世界のパターンを示す包括的な例。
+
+### 計画中のアプリ
+
+| アプリ | レベル | 実証内容 |
+|-------|-------|---------|
+| **Todo Pro** | 初級 | 状態、フォーム、ストレージ |
+| **ECサイト** | 中級 | ルーティング、HTTP、認証 |
+| **ダッシュボード** | 中級 | チャート、テーブル、リアルタイム |
+| **チャット** | 上級 | WebSocket、プッシュ通知 |
+| **メモ** | 上級 | リッチテキスト、検索、同期 |
+
+各アプリには以下が含まれます：
+- 全6プラットフォーム用の完全なソースコード
+- ステップバイステップのチュートリアル
+- アーキテクチャドキュメント
+- パフォーマンスベンチマーク
+
+## コントリビュート
+
+コントリビュートを歓迎します！詳細は[コントリビュートガイド](https://github.com/kotsutsumi/zylix/blob/main/CONTRIBUTING.md)をご覧ください。
+
+### 優先領域
+
+1. コンポーネント実装（v0.2.0）
+2. プラットフォームシェル更新
+3. ドキュメント改善
+4. サンプルアプリケーション
+
+## 詳細なロードマップ
+
+完全な実装詳細については、以下のロードマップドキュメントをご覧ください：
+
+- [ROADMAP.md](https://github.com/kotsutsumi/zylix/blob/main/docs/ROADMAP.md)（英語）
+- [ROADMAP.ja.md](https://github.com/kotsutsumi/zylix/blob/main/docs/ROADMAP.ja.md)（日本語）


### PR DESCRIPTION
## Summary

- Add roadmap pages to Hugo documentation site (English & Japanese)
- Add roadmap links to documentation index pages
- Include Mermaid diagrams and interactive tab components

## Changes

### New Files
- `site/content/en/docs/roadmap.md` - English roadmap page
- `site/content/ja/docs/roadmap.md` - Japanese roadmap page

### Modified Files
- `site/content/en/docs/_index.md` - Added roadmap card
- `site/content/ja/docs/_index.md` - Added roadmap card

## Features

- Gantt chart showing development timeline (v0.2.0 - v0.6.0)
- Tabbed component lists by category (Form, Layout, Navigation, Feedback, Data)
- Mermaid architecture diagrams for routing and async systems
- API previews for upcoming features
- Links to detailed ROADMAP.md documents

## Preview

The roadmap page includes:
- Phase 6: Component Library (v0.2.0)
- Phase 7: Routing System (v0.3.0)
- Phase 8: Async Processing (v0.4.0)
- Phase 9: Hot Reload (v0.5.0)
- Phase 10: Sample Applications (v0.6.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)