### PR TITLE
chore(ci): Add GitHub Actions CI/CD workflows

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,23 @@
+# Default owners for everything in the repo
+* @kotsutsumi
+
+# Core (Zig)
+/core/ @kotsutsumi
+
+# Platform-specific owners
+/platforms/android/ @kotsutsumi
+/platforms/ios/ @kotsutsumi
+/platforms/macos/ @kotsutsumi
+/platforms/windows/ @kotsutsumi
+/platforms/linux/ @kotsutsumi
+/platforms/web/ @kotsutsumi
+
+# Samples
+/samples/ @kotsutsumi
+
+# Documentation
+/docs/ @kotsutsumi
+/site/ @kotsutsumi
+
+# CI/CD
+/.github/ @kotsutsumi

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # Hugo modules (Go)
+  - package-ecosystem: "gomod"
+    directory: "/site"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "documentation"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,134 @@
+name: CI
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ============================================================================
+  # Core (Zig) Build
+  # ============================================================================
+  core-build:
+    name: Core Build (Zig)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Zig
+        uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.13.0
+
+      - name: Build Core
+        working-directory: core
+        run: zig build
+
+      - name: Run Core Tests
+        working-directory: core
+        run: zig build test
+        continue-on-error: true
+
+  # ============================================================================
+  # Web Platform Lint
+  # ============================================================================
+  web-lint:
+    name: Web Platform Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check JavaScript Syntax
+        run: |
+          for file in platforms/web/*.js samples/*/src/*.js; do
+            if [ -f "$file" ]; then
+              echo "Checking $file..."
+              node --check "$file" || exit 1
+            fi
+          done
+
+  # ============================================================================
+  # Windows Build
+  # ============================================================================
+  windows-build:
+    name: Windows Build (.NET)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore Dependencies
+        working-directory: platforms/windows/Zylix
+        run: dotnet restore
+        continue-on-error: true
+
+      - name: Build
+        working-directory: platforms/windows/Zylix
+        run: dotnet build --no-restore
+        continue-on-error: true
+
+  # ============================================================================
+  # Documentation Site Build
+  # ============================================================================
+  docs-build:
+    name: Documentation Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: 'latest'
+          extended: true
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build Site
+        working-directory: site
+        run: hugo --minify
+
+  # ============================================================================
+  # CodeRabbit Review (on PRs only)
+  # ============================================================================
+  coderabbit:
+    name: CodeRabbit Review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install CodeRabbit
+        run: npm install -g coderabbit
+
+      - name: Run CodeRabbit Review
+        run: coderabbit review --plain --type committed --base-commit ${{ github.event.pull_request.base.sha }}
+        continue-on-error: true
+        env:
+          CODERABBIT_API_KEY: ${{ secrets.CODERABBIT_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  # ============================================================================
+  # Create GitHub Release
+  # ============================================================================
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get Version
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Generate Changelog
+        id: changelog
+        run: |
+          # Get the previous tag
+          PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+
+          if [ -n "$PREV_TAG" ]; then
+            echo "Generating changelog from $PREV_TAG to ${{ steps.version.outputs.version }}"
+            CHANGELOG=$(git log --pretty=format:"- %s (%h)" $PREV_TAG..HEAD)
+          else
+            echo "No previous tag found, generating full changelog"
+            CHANGELOG=$(git log --pretty=format:"- %s (%h)")
+          fi
+
+          # Write to file for multi-line output
+          echo "$CHANGELOG" > changelog.txt
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: ${{ steps.version.outputs.version }}
+          body_path: changelog.txt
+          draft: false
+          prerelease: ${{ contains(steps.version.outputs.version, '-') }}
+          generate_release_notes: true
+
+  # ============================================================================
+  # Build Core for Multiple Platforms
+  # ============================================================================
+  build-core:
+    name: Build Core (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Zig
+        uses: goto-bus-stop/setup-zig@v2
+        with:
+          version: 0.13.0
+
+      - name: Build Core
+        working-directory: core
+        run: zig build -Doptimize=ReleaseFast
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: zylix-core-${{ matrix.os }}
+          path: core/zig-out/
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary

Adds GitHub Actions CI/CD infrastructure to the project.

### Added Workflows

**ci.yml** - Main CI workflow
- Runs on push to main/develop and PRs
- Core (Zig) build and test
- Web platform JavaScript syntax checking
- Windows .NET build
- Hugo documentation site build
- CodeRabbit review integration for PRs

**release.yml** - Automated release workflow
- Triggered by version tags (v*)
- Generates changelog from commits
- Creates GitHub release with release notes
- Builds core for multiple platforms (Ubuntu, macOS, Windows)

### Configuration Files

**dependabot.yml**
- Weekly updates for GitHub Actions
- Weekly updates for Hugo modules (Go)

**CODEOWNERS**
- Defines code ownership for all project areas

## Test plan

- [ ] Verify CI workflow runs on PR creation
- [ ] Verify documentation build passes
- [ ] Verify release workflow (on next tag push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)